### PR TITLE
fix: disable default on text tracks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@videojs/http-streaming",
-  "version": "3.2.0",
-  "description": "Play back HLS and DASH with Video.js, even where it's not natively supported",
+  "name": "@leonchabbey/rio-videojs-http-streaming",
+  "version": "3.2.0-1",
+  "description": "https://github.com/SRGSSR/rio-videojs-http-streaming/pull/1",
   "main": "dist/videojs-http-streaming.cjs.js",
   "module": "dist/videojs-http-streaming.es.js",
   "repository": {

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -600,7 +600,8 @@ export const initialize = {
           const track = tech.addRemoteTextTrack({
             id: variantLabel,
             kind: 'subtitles',
-            default: properties.default && properties.autoselect,
+            // Disable until we can tell Stipo to not set default to true on text tracks
+            default: false,
             language: properties.language,
             label: variantLabel
           }, false).track;
@@ -653,7 +654,8 @@ export const initialize = {
           label: variantLabel,
           language: properties.language,
           instreamId: properties.instreamId,
-          default: properties.default && properties.autoselect
+          // Disable until we can tell Stipo to not set default to true on text tracks
+          default: false
         };
 
         if (captionServices[newProps.instreamId]) {
@@ -672,7 +674,8 @@ export const initialize = {
           const track = tech.addRemoteTextTrack({
             id: newProps.instreamId,
             kind: 'captions',
-            default: newProps.default,
+            // Disable until we can tell Stipo to not set default to true on text tracks
+            default: false,
             language: newProps.language,
             label: newProps.label
           }, false).track;


### PR DESCRIPTION
Temporary "fix" until Stipo supports setting all text tracks to `default: false`. 

Right now, we manage the showing text track in the client directly

https://www.npmjs.com/package/@leonchabbey/rio-videojs-http-streaming